### PR TITLE
TASKLETS-10 count descendants with CTE SQL query

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,8 +5,30 @@ class Task < ActiveRecord::Base
 
   # https://guides.rubyonrails.org/association_basics.html#self-joins
   # to create a tree structure.
-  has_many :children, class_name: "Task", foreign_key: "parent_id"
-  belongs_to :parent, class_name: "Task", optional: true
+  has_many :children, class_name: 'Task', foreign_key: 'parent_id'
+  belongs_to :parent, class_name: 'Task', optional: true
 
   validates :description, presence: true
+
+  def self.count_descendents_with_cte(id = nil)
+    descendents_with_cte(id)[0]['count']
+  end
+
+  def self.descendents_with_cte(id)
+    id = id.nil? ? 'IS NULL' : "= #{id}"
+
+    # This pulls all the descendents into a flat array.
+    sql = <<-SQL
+      WITH RECURSIVE tree AS (
+        select t.id, t.parent_id, t.tags from tasks t where parent_id #{id}
+        UNION ALL
+        select t1.id, t1.parent_id, t1.tags from tree
+        join tasks t1 ON t1.parent_id = tree.id
+      ) SELECT count(*) FROM tree
+    SQL
+
+    # connection is in the ConnectionHandling module which is included in Base:
+    # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/base.rb#L271
+    ActiveRecord::Base.connection.execute(sql)
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'json'
+require 'pry'
 
 RSpec.describe Task do
   it "doesn't save an invalid model" do
@@ -16,5 +18,44 @@ RSpec.describe Task do
     task = create :task
     task.children << create(:task)
     expect(Task.count).to be 2
+  end
+
+  describe '.count_descendents_with_cte' do
+    before :all do
+      user = User.create(email: 'foo@bar.com')
+      root = Task.create!(tags: 'Animalia', description: 'Top level root of tree', user: user)
+      root.children.create(tags: 'Rotifers', description: 'second level of tree', user: user)
+      root.children.create(tags: 'Sponges', description: 'second level of tree', user: user)
+      chordates = root.children.create(tags: 'Chordates', description: 'second level of tree', user: user)
+      chordates.children.create(tags: 'Amphibian', description: 'third level of tree', user: user)
+      chordates.children.create(tags: 'Mammalia', description: 'third level of tree', user: user)
+    end
+
+    it 'counts records' do
+      expect(Task.count).to be 6
+    end
+
+    it 'counts descendents of root' do
+      count = Task.count_descendents_with_cte
+      expect(count).to be 6
+    end
+
+    it 'counts descendents of Rotifers' do
+      parent_id = Task.find_by(tags: 'Rotifers').id
+      count = Task.count_descendents_with_cte(parent_id)
+      expect(count).to be 0
+    end
+
+    it 'counts descendents of Sponges' do
+      parent_id = Task.find_by(tags: 'Sponges').id
+      count = Task.count_descendents_with_cte(parent_id)
+      expect(count).to be 0
+    end
+
+    it 'counts descendents of Chordates' do
+      parent_id = Task.find_by(tags: 'Chordates').id
+      count = Task.count_descendents_with_cte(parent_id)
+      expect(count).to be 2
+    end
   end
 end


### PR DESCRIPTION
Rails doesn't support CTE queries, so it's necessary
to construct CTEs using SQL then executing the query
via a database connection.

The query returns a tuple of hashes, which isn't terribly
useful if one is interested in either the actual models,
or representing the nested structure.

It's trivial to count the results which is what this
change demonstrates.