### PR TITLE
TASKLETS-9 Change CI/CD to semaphoreci from travis-ci

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,13 @@
+version: v1.0
+name: Initial Pipeline
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: 'Block #1'
+    task:
+      jobs:
+        - name: 'Job #1'
+          commands:
+            - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-script: "bundle exec rake db:drop db:create db:migrate spec"
-bundler_args: "--binstubs"
-rvm:
-  - 2.6.3


### PR DESCRIPTION
travis-ci configuration isn't working right now, and cursory attempts to
fix it have failed. Since we're using semaphoreci at work, and it's
easier to configure (and likely more powerful), switch from travis-ci to
semaphoreci.