### PR TITLE
TASKLETS-6 add required attribute label to Task

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def permitted_params
-        params.require(:task).permit(:description)
+        params.require(:task).permit(:description, :label)
       end
     end
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -35,7 +35,7 @@ class TasksController < ApplicationController
   end
 
   def permitted_params
-    params.require(:task).permit(:description, :started, :tags)
+    params.require(:task).permit(:description, :started, :tags, :label)
   end
 
   def create

--- a/app/validators/task_label_validator.rb
+++ b/app/validators/task_label_validator.rb
@@ -1,0 +1,7 @@
+class TaskLabelValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value && value.length < 64
+      record.errors.add(attribute, :on_label)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,14 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+activerecord:
+  attributes:
+    user:
+      email: 'E-mail address'
+  errors:
+    models:
+      task:
+        attributes:
+          label:
+            blank: 'is required'
+            on_label: 'length 64 or less'

--- a/db/migrate/20200917113911_add_label_to_tasks.rb
+++ b/db/migrate/20200917113911_add_label_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddLabelToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_121149) do
+ActiveRecord::Schema.define(version: 2020_09_17_113911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2020_08_28_121149) do
     t.string "tags"
     t.integer "user_id"
     t.bigint "parent_id"
+    t.string "label"
     t.index ["parent_id"], name: "index_tasks_on_parent_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,20 +2,20 @@
 
 # rake db:reset will drop the at least the testing and development databases,
 # and run db:seed to create the following in the development database. Running
-# tasklets_development=# select tags, id, parent_id from tasks where parent_id IS NULL;
+# tasklets_development=# select label, id, parent_id from tasks where parent_id IS NULL;
 # at the psql command line should return the Animalia record.
 user = User.create(email: 'foo@bar.com')
-root = Task.create!(tags: 'Animalia', description: 'Top level root of tree', user: user)
+root = Task.create!(label: 'Animalia', description: 'Top level root of tree', user: user)
 
 # Leverage the built in associations methods:
 # https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html
-root.children.create(tags: 'Rotifers', description: 'second level of tree', user: user)
-root.children.create(tags: 'Sponges', description: 'second level of tree', user: user)
-chordates = root.children.create(tags: 'Chordates', description: 'second level of tree', user: user)
+root.children.create(label: 'Rotifers', description: 'second level of tree', user: user)
+root.children.create(label: 'Sponges', description: 'second level of tree', user: user)
+chordates = root.children.create(label: 'Chordates', description: 'second level of tree', user: user)
 
-chordates.children.create(tags: 'Amphibian', description: 'third level of tree', user: user)
-mammalia = chordates.children.create(tags: 'Mammalia', description: 'third level of tree', user: user)
+chordates.children.create(label: 'Amphibian', description: 'third level of tree', user: user)
+mammalia = chordates.children.create(label: 'Mammalia', description: 'third level of tree', user: user)
 
-mammalia.children.create(tags: 'Rodents', description: '4th level', user: user)
-mammalia.children.create(tags: 'Cats', description: '4th level', user: user)
-mammalia.children.create(tags: 'Dogs', description: '4th level', user: user)
+mammalia.children.create(label: 'Rodents', description: '4th level', user: user)
+mammalia.children.create(label: 'Cats', description: '4th level', user: user)
+mammalia.children.create(label: 'Dogs', description: '4th level', user: user)

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -8,13 +8,10 @@ module Api
       let(:user) { create :user }
       before { request.headers.merge! user.create_new_auth_token }
 
-      describe '#index' do
-      end
-
       describe '#create' do
         it 'a task for signed in user' do
           expect do
-            post :create, params: { task: { description: 'some task' } }
+            post :create, params: { task: { description: 'some task', label: 'some label' } }
             expect(response).to have_http_status(:created)
           end.to change { Task.count }.by 1
         end
@@ -22,7 +19,7 @@ module Api
 
       describe '#show' do
         it 'task found by task id' do
-          task = Task.create! description: 'foobar', user: user
+          task = create :task
           get :show, params: { id: task.id }
           expect(response).to have_http_status(:ok)
         end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -73,7 +73,8 @@ describe TasksController, type: :controller do
         parameters = {
           task: {
             description: 'some description',
-            tags: tags
+            tags: tags,
+            label: 'some label'
           }
         }
 
@@ -85,7 +86,7 @@ describe TasksController, type: :controller do
 
       it 'redirects to the created task' do
         create :user, email: 'foo@bar.com'
-        post :create, params: { task: { description: 'some description' } }
+        post :create, params: { task: { description: 'some description', label: 'some label' } }
 
         aggregate_failures do
           expect(response).to have_http_status(:redirect)

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :task do
     description { 'Task description dummy text.' }
+    label { 'dummy label' }
     association :user
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -20,41 +20,47 @@ RSpec.describe Task do
       task.children << create(:task)
       expect(Task.count).to be 2
     end
+
+    context 'label' do
+      it 'rejects log strings' do
+        expect(build(:task, label: 'a'*65).valid?).to be false
+      end
+    end
   end
 
   context 'extracting records' do
     before :all do
       user = User.create(email: 'foo@bar.com')
-      root = Task.create!(tags: 'Animalia', description: 'Top level root of tree', user: user)
-      chordates = root.children.create(tags: 'Chordates', description: 'second level of tree', user: user)
-      root.children.create(tags: 'Sponges', description: 'second level of tree', user: user)
-      root.children.create(tags: 'Rotifers', description: 'second level of tree', user: user)
-      chordates.children.create(tags: 'Mammalia', description: 'third level of tree', user: user)
-      chordates.children.create(tags: 'Amphibian', description: 'third level of tree', user: user)
+      root = Task.create!(label: 'Animalia', description: 'Top level root of tree', user: user)
+      chordates = root.children.create(label: 'Chordates', description: 'second level of tree', user: user)
+      root.children.create(label: 'Sponges', description: 'second level of tree', user: user)
+      root.children.create(label: 'Rotifers', description: 'second level of tree', user: user)
+      chordates.children.create(label: 'Mammalia', description: 'third level of tree', user: user)
+      chordates.children.create(label: 'Amphibian', description: 'third level of tree', user: user)
     end
 
     describe '#descendants' do
       it 'builds tree from root using repeated database calls' do
         expected = {
-          tags: 'Animalia',
+          label: 'Animalia',
           children: [{
-            tags: 'Chordates',
+            label: 'Chordates',
             children: [{
-              tags: 'Mammalia',
+              label: 'Mammalia',
               children: []
             }, {
-              tags: 'Amphibian',
+              label: 'Amphibian',
               children: []
             }]
           }, {
-            tags: 'Sponges',
+            label: 'Sponges',
             children: []
           }, {
-            tags: 'Rotifers',
+            label: 'Rotifers',
             children: []
           }]
         }.to_json
-        actual = Task.find_by(tags: 'Animalia').descendants.to_json
+        actual = Task.find_by(label: 'Animalia').descendants.to_json
         expect(actual).to eq expected
       end
     end
@@ -66,19 +72,19 @@ RSpec.describe Task do
       end
 
       it 'counts descendants of Rotifers' do
-        parent_id = Task.find_by(tags: 'Rotifers').id
+        parent_id = Task.find_by(label: 'Rotifers').id
         count = Task.count_descendants_with_cte(parent_id)
         expect(count).to be 0
       end
 
       it 'counts descendants of Sponges' do
-        parent_id = Task.find_by(tags: 'Sponges').id
+        parent_id = Task.find_by(label: 'Sponges').id
         count = Task.count_descendants_with_cte(parent_id)
         expect(count).to be 0
       end
 
       it 'counts descendants of Chordates' do
-        parent_id = Task.find_by(tags: 'Chordates').id
+        parent_id = Task.find_by(label: 'Chordates').id
         count = Task.count_descendants_with_cte(parent_id)
         expect(count).to be 2
       end
@@ -97,23 +103,23 @@ RSpec.describe Task do
         expected = {
           'id' => 1,
           'parent_id' => nil,
-          'tags' => 'Animalia',
+          'label' => 'Animalia',
           'children' => [
             {
               'id' => 2,
               'parent_id' => 1,
-              'tags' => 'Chordates',
+              'label' => 'Chordates',
               'children' => [
                 {
                   'id' => 5,
                   'parent_id' => 2,
-                  'tags' => 'Mammalia',
+                  'label' => 'Mammalia',
                   'children' => []
                 },
                 {
                   'id' => 6,
                   'parent_id' => 2,
-                  'tags' => 'Amphibian',
+                  'label' => 'Amphibian',
                   'children' => []
                 }
               ]
@@ -121,12 +127,12 @@ RSpec.describe Task do
             {
               'id' => 3,
               'parent_id' => 1,
-              'tags' => 'Sponges',
+              'label' => 'Sponges',
               'children' => []
             }, {
               'id' => 4,
               'parent_id' => 1,
-              'tags' => 'Rotifers',
+              'label' => 'Rotifers',
               'children' => []
             }
           ]

--- a/spec/requests/api/v1/tasks_request_spec.rb
+++ b/spec/requests/api/v1/tasks_request_spec.rb
@@ -18,7 +18,7 @@ module Api
 
       describe 'api_v1_tasks_url' do
         it 'creates a task for signed in user' do
-          parameters = { task: { description: 'some task' } }
+          parameters = { task: { description: 'some task', label: 'some label' } }
 
           expect do
             post api_v1_tasks_url, params: parameters, headers: header_params
@@ -29,8 +29,7 @@ module Api
 
       describe 'api_v1_task_url/:id' do
         it 'returns task specified by :id' do
-          task = Task.create! description: 'foobar', user: user
-
+          task = create :task
           get api_v1_task_url(task), headers: header_params
           expect(response).to have_http_status(:ok)
         end

--- a/spec/requests/tasks_request_spec.rb
+++ b/spec/requests/tasks_request_spec.rb
@@ -64,7 +64,8 @@ describe TasksController, type: :request do
         parameters = {
           task: {
             description: 'some description',
-            tags: tags
+            tags: tags,
+            label: 'some label'
           }
         }
         expect do
@@ -75,12 +76,12 @@ describe TasksController, type: :request do
 
       it 'assigns a newly created task as @task' do
         create :user, email: 'foo@bar.com'
-        post tasks_url, params: { task: { description: 'some description' } }
+        post tasks_url, params: { task: { description: 'some description', label: 'some label' } }
         expect(response).to have_http_status(:redirect)
       end
 
       it 'redirects to the created task' do
-        post tasks_url, params: { task: { description: 'some description' } }
+        post tasks_url, params: { task: { description: 'some description', label: 'some label' } }
         expect(response).to redirect_to(task_url(Task.last))
       end
     end


### PR DESCRIPTION
Saving multiple trees into the same relation requires
a better way to differentiate between trees other than
"parent_id = nil".

This changes resolves the multiple tree conundrum using
a label for each node in the tree, including the root node.

Added a custom validator to get the pattern in place.