### PR TITLE
TASKLETS-13 count children correctly.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,13 +5,14 @@
 # tasklets_development=# select label, id, parent_id from tasks where parent_id IS NULL;
 # at the psql command line should return the Animalia record.
 user = User.create(email: 'foo@bar.com')
-root = Task.create!(label: 'Animalia', description: 'Top level root of tree', user: user)
+
+root1 = Task.create!(label: 'Animalia', description: 'Top level root of tree', user: user)
 
 # Leverage the built in associations methods:
 # https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html
-root.children.create(label: 'Rotifers', description: 'second level of tree', user: user)
-root.children.create(label: 'Sponges', description: 'second level of tree', user: user)
-chordates = root.children.create(label: 'Chordates', description: 'second level of tree', user: user)
+root1.children.create(label: 'Rotifers', description: 'second level of tree', user: user)
+root1.children.create(label: 'Sponges', description: 'second level of tree', user: user)
+chordates = root1.children.create(label: 'Chordates', description: 'second level of tree', user: user)
 
 chordates.children.create(label: 'Amphibian', description: 'third level of tree', user: user)
 mammalia = chordates.children.create(label: 'Mammalia', description: 'third level of tree', user: user)
@@ -19,3 +20,9 @@ mammalia = chordates.children.create(label: 'Mammalia', description: 'third leve
 mammalia.children.create(label: 'Rodents', description: '4th level', user: user)
 mammalia.children.create(label: 'Cats', description: '4th level', user: user)
 mammalia.children.create(label: 'Dogs', description: '4th level', user: user)
+
+root2 = Task.create!(label: 'Plants', description: 'Top level root of tree', user: user)
+forbes = root2.children.create(label: 'Forbes', description: 'second level of tree', user: user)
+trees = root2.children.create(label: 'Trees', description: 'second level of tree', user: user)
+trees.children.create(label: 'Evergreen', description: 'third level of tree', user: user)
+trees.children.create(label: 'Deciduous', description: 'third level of tree', user: user)


### PR DESCRIPTION
Finding a tree by its parent id is a problem when there
is more than one tree, and the tree is rooted by having
a parent id equal to null. It makes it difficult to
query just a single tree.

In this change, every node is labeled, including the root
node. For now, labels are not unique, but that will need to
be dealt with at some point.