### PR TITLE
TASKLETS-40 prevent task creation with nonexistent parent_id

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,11 +5,19 @@ class Task < ActiveRecord::Base
 
   # https://guides.rubyonrails.org/association_basics.html#self-joins
   # to create a tree structure.
+  # TODO: look into foreign key gem.
   has_many :children, class_name: 'Task', foreign_key: 'parent_id'
   belongs_to :parent, class_name: 'Task', optional: true
 
   validates_with TaskLabelValidator, attributes: [:label]
   validates :description, presence: true
+  validates :parent_id, with: :parent_exists_or_nil
+
+  def parent_exists_or_nil
+    return true if parent_id.nil?
+    return true if Task.exists?(parent_id)
+    errors.add(:parent_id, :parent_id_exists)
+  end
 
   # This is a nasty way to do it, makes a database call for each record.
   # But it does work!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,9 +35,14 @@ activerecord:
     user:
       email: 'E-mail address'
   errors:
+    messages:
+      parent_id_exists: 'from yaml'
     models:
       task:
+        parent_id_exists: 'higher yaml'
         attributes:
           label:
             blank: 'is required'
             on_label: 'length 64 or less'
+          parent_id:
+            parent_id_exists: 'from yaml'

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Task do
         expect(build(:task, label: 'a' * 65).valid?).to be false
       end
     end
+
+    context 'parent_id' do
+      it 'rejects unless parent is nil or exists' do
+        expect(build(:task, parent_id: 42).valid?).to be false
+      end
+    end
   end
 
   context 'extracting records' do


### PR DESCRIPTION
Creating a task with a parent_id nil is fine, it creates a
new tree. For non-nil parent_ids, the parent_id needs to be
checked for existence.

Cases:

* parent_id non-nil and exists: valid, create the task
* parent_id non-nil but does not exist: invalid, raise.