### PR TITLE
TASKLETS-49 fix en.yml to allow custom error messages

### DIFF
--- a/app/validators/task_label_validator.rb
+++ b/app/validators/task_label_validator.rb
@@ -1,7 +1,5 @@
 class TaskLabelValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless value && value.length < 64
-      record.errors.add(attribute, :on_label)
-    end
+    record.errors.add(attribute, :on_label) unless value && value.length < 64
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,19 +30,19 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-activerecord:
-  attributes:
-    user:
-      email: 'E-mail address'
-  errors:
-    messages:
-      parent_id_exists: 'from yaml'
-    models:
-      task:
-        parent_id_exists: 'higher yaml'
-        attributes:
-          label:
-            blank: 'is required'
-            on_label: 'length 64 or less'
-          parent_id:
-            parent_id_exists: 'from yaml'
+  activerecord:
+    attributes:
+      user:
+        email: 'E-mail address'
+    errors:
+      messages:
+        parent_id_exists: 'from yaml'
+      models:
+        task:
+          parent_id_exists: 'higher yaml'
+          attributes:
+            label:
+              blank: 'is required'
+              on_label: 'length 64 or less'
+            parent_id:
+              parent_id_exists: 'id must reference a valid task or be nil'

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -23,13 +23,17 @@ RSpec.describe Task do
 
     context 'label' do
       it 'rejects log strings' do
-        expect(build(:task, label: 'a' * 65).valid?).to be false
+        expect do
+          create(:task, label: 'a' * 65)
+        end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Label length 64 or less')
       end
     end
 
     context 'parent_id' do
       it 'rejects unless parent is nil or exists' do
-        expect(build(:task, parent_id: 42).valid?).to be false
+        expect do
+          create(:task, parent_id: 42)
+        end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Parent id must reference a valid task or be nil')
       end
     end
   end


### PR DESCRIPTION
Rails was unable to find the correct custom error message
in `en.yml`, failing with `ActiveRecord::RecordInvalid: translation
missing`.

It turns out the en.yml file was misconfigured, indented improperly.

Once properly indented, custom validation messages worked correctly.