### PR TITLE
TASKLETS-39 Task update enforcing valid tree

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,6 +16,7 @@ class Task < ActiveRecord::Base
   def parent_exists_or_nil
     return true if parent_id.nil?
     return true if Task.exists?(parent_id)
+
     errors.add(:parent_id, :parent_id_exists)
   end
 


### PR DESCRIPTION
A task which has a parent_id referencing a non-existent
task is an orphan. This change prevents orphans from
occurring when tasks call `update!` with a `parent_id`.

What isn't handled in this change is orphans created
when bypassing validations. That's an interesting
project for a later date.