### PR TITLE
TASKLETS-41 hook up rubocop to semaphoreci

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -189,6 +189,10 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
+  Enabled: true
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'lib/tasks/*'
   Max: 135
 
 # Offense count: 1
@@ -353,6 +357,7 @@ Style/FrozenStringLiteralComment:
     - 'config/puma.rb'
     - 'config/spring.rb'
     - 'db/schema.rb'
+    - 'db/migrate/**/*.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development do
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'rubocop-performance'
+  gem 'meowcop'
   gem 'mry'
   gem 'listen'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    meowcop (2.14.0)
+      rubocop (>= 0.90.0, < 1.0.0)
     method_source (0.9.2)
     mime-types (3.3)
       mime-types-data (~> 3.2015)
@@ -322,20 +324,21 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    rubocop (0.90.0)
+    rubocop (0.91.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.7)
       rexml
-      rubocop-ast (>= 0.3.0, < 1.0)
+      rubocop-ast (>= 0.4.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.4.0)
+    rubocop-ast (0.4.2)
       parser (>= 2.7.1.4)
-    rubocop-performance (1.8.0)
+    rubocop-performance (1.8.1)
       rubocop (>= 0.87.0)
-    rubocop-rails (2.8.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.8.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
@@ -438,6 +441,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen
+  meowcop
   mry
   pg
   pry

--- a/app/validators/task_label_validator.rb
+++ b/app/validators/task_label_validator.rb
@@ -1,3 +1,11 @@
+# frozen_string_literal: true
+
+# Tasks need a way to be identified regardless of their
+# position in a particular tree. Specifically, a table may
+# contain multiple "trees", that is, tasks with parent_id
+# NULL. Acquiring a task tree for a particular root node
+# requires selecting that root node correctly, for which
+# the label is used.
 class TaskLabelValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     record.errors.add(attribute, :on_label) unless value && value.length < 64

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,7 @@ mammalia.children.create(label: 'Cats', description: '4th level', user: user)
 mammalia.children.create(label: 'Dogs', description: '4th level', user: user)
 
 root2 = Task.create!(label: 'Plants', description: 'Top level root of tree', user: user)
-forbes = root2.children.create(label: 'Forbes', description: 'second level of tree', user: user)
+root2.children.create(label: 'Forbes', description: 'second level of tree', user: user)
 trees = root2.children.create(label: 'Trees', description: 'second level of tree', user: user)
 trees.children.create(label: 'Evergreen', description: 'third level of tree', user: user)
 trees.children.create(label: 'Deciduous', description: 'third level of tree', user: user)

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Task do
       chordates.children.create(label: 'Reptilia', description: 'third level of tree', user: user)
 
       root2 = Task.create!(label: 'Plants', description: 'Top level root of tree', user: user)
-      forbes = root2.children.create(label: 'Forbes', description: 'second level of tree', user: user)
+      root2.children.create(label: 'Forbes', description: 'second level of tree', user: user)
       trees = root2.children.create(label: 'Trees', description: 'second level of tree', user: user)
       trees.children.create(label: 'Evergreen', description: 'third level of tree', user: user)
       trees.children.create(label: 'Deciduous', description: 'third level of tree', user: user)
@@ -147,7 +147,6 @@ RSpec.describe Task do
       end
 
       it 'at Chordates' do
-        parent_id = Task.find_by(label: 'Chordates').id
         count = Task.size_with_cte('Chordates')
         expect(count).to be 4
       end
@@ -155,7 +154,6 @@ RSpec.describe Task do
 
     describe '.count_descendants_with_cte' do
       it 'counts descendants of root' do
-        # TODO: We're counting on an implicit nil here for parent_id TASKLETS-13
         count = Task.count_descendants_with_cte('Animalia')
         expect(count).to be 5
       end
@@ -173,7 +171,6 @@ RSpec.describe Task do
       end
 
       it 'counts descendants of Chordates' do
-        parent_id = Task.find_by(label: 'Chordates').id
         count = Task.count_descendants_with_cte('Chordates')
         expect(count).to be 3
       end
@@ -189,7 +186,8 @@ RSpec.describe Task do
 
     describe '.to_hash' do
       it 'returns tree from root in hash form' do
-        expected = {
+        # TODO: find a way to test output structure TASKLETS-54
+        _expected = {
           'id' => 1,
           'parent_id' => nil,
           'label' => 'Animalia',


### PR DESCRIPTION
This change  updates the various rubocop gems, and fixes a few
preexisting violations. Normally, violations would get separate commits
to allow for easier revert if necessary, but the context here allows
"bending the rules" a bit.