### PR TITLE
TASKLETS-32 hook up rubocop to semaphoreci

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,16 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+#require:
+#  - rubocop-rails
+#  - rubocop-performance
+
 AllCops:
   NewCops: enable
   Exclude:
     - 'config.ru'
     - 'db/schema.rb'
+    - 'vendor/**/*'
 
 # Offense count: 11
 # Cop supports --auto-correct.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,6 +33,11 @@ blocks:
           - checkout
           - cache restore
       jobs:
+        - name: Linting for the win
+          commands:
+            - bundle config set path 'vendor/bundle'
+            - bundle install
+            - bundle exec rubocop --parallel
         - name: Run specs
           commands:
             - sem-version ruby 2.7.1

--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,6 @@ group :development do
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'rubocop-performance'
-  gem 'meowcop'
-  gem 'mry'
   gem 'listen'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,8 +208,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    meowcop (2.14.0)
-      rubocop (>= 0.90.0, < 1.0.0)
     method_source (0.9.2)
     mime-types (3.3)
       mime-types-data (~> 3.2015)
@@ -222,8 +220,6 @@ GEM
       minitar (~> 0.8.0)
       powerbar (~> 1.0)
     minitest (5.14.2)
-    mry (0.78.0.0)
-      rubocop (>= 0.41.0)
     multi_json (1.14.1)
     multi_test (0.1.2)
     netrc (0.11.0)
@@ -441,8 +437,6 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen
-  meowcop
-  mry
   pg
   pry
   pry-nav


### PR DESCRIPTION
Require passing rubocop before allowing merge.

The key to making this work is excluding `vendor/**/*`.
Otherwise rubocop tries to lint all the gems, which doesn't
end well.