### PR TITLE
TASKLETS-59 fix cucumber feature/task failure

### DIFF
--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -12,6 +12,10 @@
     %br/
     = f.text_field :description
   .field
+    = f.label :label
+    %br/
+    = f.text_field :label
+  .field
     = f.label :tags
     %br/
     = f.text_field :tags

--- a/features/step_definitions/task_steps.rb
+++ b/features/step_definitions/task_steps.rb
@@ -24,10 +24,10 @@ Given /^I fill in the "([^"]*)" with "([^"]*)"$/ do |field, value|
   fill_in(field, with: value)
 end
 
-When(/^I pressem button "(.*?)"$/) do |arg1|
+When(/^I press button "(.*?)"$/) do |arg1|
   click_button 'Create Task'
 end
 
-Then(/^I'ma get "(.*?)"$/) do |arg1|
+Then(/^I see message "(.*?)"$/) do |arg1|
   page.body.should have_selector '.flash.success', text: 'Task was successfully created.'
 end

--- a/features/task.feature
+++ b/features/task.feature
@@ -3,10 +3,11 @@ Feature: User manages tasks
   Scenario: Logged in user adds a task
     Given I am signed in
     And on the new task page
-    #Then show me the page
+    # Then show me the page
     And I fill in the "Description" with "Task"
-    When I pressem button "Create Task"
-    Then I'ma get "Task was successfully created."
+    And I fill in the "Label" with "label"
+    When I press button "Create Task"
+    Then I see message "Task was successfully created."
 
   @wip
   Scenario: Logged in user deletes a task


### PR DESCRIPTION
When label was made a required attribute for a task,
the corresponding for was not updated, inducing a
cucumber failure on that form.

A great argument for keeping cucumber in play.