### PR TITLE
TASKLETS-76 task delete via cascade

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,7 +5,12 @@ class Task < ApplicationRecord
 
   # https://guides.rubyonrails.org/association_basics.html#self-joins
   # to create a tree structure.
-  # TODO: look into foreign key gem.
+  # Note: there is a migration which adds a postgres foreign key constrain to the Tasks
+  # table. It is not clear how that interacts with the dependent: :destroy parameter.
+  #
+  # TODO: follow up on how Rails dependent: :destroy interacts with a postgres defined
+  # foreign key constraint. This will require watching the postgres logs as the Rails
+  # destroy event is invoked.
   has_many :children, class_name: 'Task', foreign_key: 'parent_id', dependent: :destroy, inverse_of: :parent
   belongs_to :parent, class_name: 'Task', optional: true
 

--- a/db/migrate/20200924110238_add_foriegn_key_to_tasklets.rb
+++ b/db/migrate/20200924110238_add_foriegn_key_to_tasklets.rb
@@ -1,0 +1,18 @@
+class AddForiegnKeyToTasklets < ActiveRecord::Migration[6.0]
+  def up
+    # https://stackoverflow.com/questions/3711580/how-does-one-write-a-delete-cascade-for-postgres
+    # https://stackoverflow.com/questions/3711580/how-does-one-write-a-delete-cascade-for-postgres
+    # https://pawelurbanek.com/rails-postgresql-data-integrity
+    # Note: using cascade will bypass any AR destroy callbacks defined on the deleted models.
+    #
+    # TODO: tinker with the dependent destroy on the Rails model and watch the postgres logs to
+    # see how that interacts with the foreign key cascade.
+    sql = 'ALTER TABLE ONLY tasks ADD CONSTRAINT tasks_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES tasks (id) ON DELETE CASCADE'
+    ActiveRecord::Base.connection.execute sql
+  end
+
+  def down
+    sql = 'ALTER TABLE tasks DROP CONSTRAINT tasks_parent_id_fkey'
+    ActiveRecord::Base.connection.execute sql
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_17_113911) do
+ActiveRecord::Schema.define(version: 2020_09_24_110238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,4 +75,5 @@ ActiveRecord::Schema.define(version: 2020_09_17_113911) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "tasks", "tasks", column: "parent_id", name: "tasks_parent_id_fkey", on_delete: :cascade
 end


### PR DESCRIPTION
Migration adds a postgres foreign key constrain to the Tasks
table. This works really well at the database level, fast and
accurate.

It is not clear how that interacts with the dependent: :destroy
parameter passed into the AR association on the Task model.

Note that using CASCADE will bypass any AR delete/destroy callbacks
defined on the deleted models.

The following were very useful:

* https://stackoverflow.com/questions/3711580/how-does-one-write-a-delete-cascade-for-postgres
* https://stackoverflow.com/questions/3711580/how-does-one-write-a-delete-cascade-for-postgres
* https://pawelurbanek.com/rails-postgresql-data-integrity

TODO: follow up on how Rails dependent: :destroy interacts with a postgres defined
foreign key constraint. This will require watching the postgres logs as the Rails
destroy event is invoked.