### PR TITLE
TASKLETS-81 rspec fail fast to speed pipeline

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---color
+--color --fail-fast


### PR DESCRIPTION
No need to run the CI/CD pipeline if rspec fails at all,
so making it fail fast can't hurt.