### PR TITLE
TASKLETS-75 move CTE query builder to service class

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -85,32 +85,4 @@ class Task < ApplicationRecord
     # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/base.rb#L271
     ActiveRecord::Base.connection.execute(sql)
   end
-
-  class CteQueryBuilder
-    def self.descendants(label)
-      # id = id.nil? ? 'IS NULL' : "= #{id}"
-
-      # This pulls all the descendants into a flat array.
-      <<-SQL.squish
-        WITH RECURSIVE tree AS (
-          select t.id, t.parent_id, t.label from tasks t where label = \'#{label}\'
-          UNION ALL
-          select t1.id, t1.parent_id, t1.label from tree
-          join tasks t1 ON t1.parent_id = tree.id
-        )
-      SQL
-    end
-
-    def self.descendants_cte(id)
-      "#{descendants(id)} select id, parent_id, label from tree"
-    end
-
-    def self.descendants_count(id)
-      "#{descendants(id)} SELECT count(*) FROM tree where parent_id IS NOT NULL"
-    end
-
-    def self.descendants_delete(id)
-      "#{descendants(id)}  delete from tasks where id in (select id from tree)"
-    end
-  end
 end

--- a/app/services/cte_query_builder.rb
+++ b/app/services/cte_query_builder.rb
@@ -1,0 +1,30 @@
+# frozen-string-literal: true
+
+# Common Table Expressions are not yet handled natively in Rails,
+# so here is a service class for building such queries. The class
+# does not do any database access at, it simply builds a SQL statement
+# which is handed off to the caller.
+class CteQueryBuilder
+  def self.descendants(label)
+    <<-SQL.squish
+        WITH RECURSIVE tree AS (
+          select t.id, t.parent_id, t.label from tasks t where label = \'#{label}\'
+          UNION ALL
+          select t1.id, t1.parent_id, t1.label from tree
+          join tasks t1 ON t1.parent_id = tree.id
+        )
+    SQL
+  end
+
+  def self.descendants_cte(label)
+    "#{descendants(label)} select id, parent_id, label from tree"
+  end
+
+  def self.descendants_count(label)
+    "#{descendants(label)} SELECT count(*) FROM tree where parent_id IS NOT NULL"
+  end
+
+  def self.descendants_delete(label)
+    "#{descendants(label)} delete from tasks where id in (select id from tree)"
+  end
+end

--- a/spec/services/cte_query_builder_spec.rb
+++ b/spec/services/cte_query_builder_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The purpose of testing the CteQueryBuilder is to make it more difficult
+# to introduce regressions into the code. The SQL can be very sensitive
+# and if it fails, difficult to debug. The tests here enforce consistency
+# between the class and the test, and have nothing to do with the validity
+# of the SQL, which is tested elsewhere.
+RSpec.describe CteQueryBuilder do
+  let(:label) { 'platypus' }
+  let(:cte) do
+    <<-SQL.squish
+      WITH RECURSIVE tree AS (
+        select t.id, t.parent_id, t.label from tasks t where label = \'#{label}\'
+        UNION ALL
+        select t1.id, t1.parent_id, t1.label from tree
+        join tasks t1 ON t1.parent_id = tree.id
+      )
+    SQL
+  end
+
+  describe '.descendants' do
+    it 'builds the base CTE' do
+      expect(described_class.descendants(label)).to eq cte
+    end
+  end
+
+  describe '.descendants_cte' do
+    it 'selects the descendants from base CTE' do
+      expected = "#{cte} select id, parent_id, label from tree"
+      expect(described_class.descendants_cte(label)).to eq expected
+    end
+  end
+
+  describe '.descendants_count' do
+    it 'counts the descendants using the base CTE' do
+      expected = "#{cte} SELECT count(*) FROM tree where parent_id IS NOT NULL"
+      expect(described_class.descendants_count(label)).to eq expected
+    end
+  end
+
+  describe '.descendants_delete' do
+    it 'deletes the descendants from base CTE' do
+      expected = "#{cte} delete from tasks where id in (select id from tree)"
+      expect(described_class.descendants_delete(label)).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
Common Table Expressions are not yet handled natively in Rails,
so here is a service class for building such queries. The class
does not do any database access at, it simply builds a SQL statement
which is handed off to the caller.

The methods in the class were extracted with the class from the Task
model.

The purpose of testing the CteQueryBuilder is to make it more difficult
to introduce regressions into the code. The SQL can be very sensitive
and if it fails, difficult to debug. The specs here enforce consistency
between the class and the specs, and have nothing to do with the validity
of the SQL, which is tested elsewhere.