### PR TITLE
TASKLETS-97 update unf_ext gem to 0.0.7.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,7 +414,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     unicorn (5.7.0)
       kgio (~> 2.6)


### PR DESCRIPTION
Unicode Normalization Form support library for CRuby
Normalizes UTF-8 strings into and from NFC, NFD, NFKC or NFKD

Loads an .so file from c++ source.