### PR TITLE
TASKLETS-83 fix coverband operation

### DIFF
--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,0 +1,20 @@
+# frozen-string-literal: true
+
+Coverband.configure do |config|
+  config.store = Coverband::Adapters::RedisStore.new(Redis.new(url: ENV['REDISTOGO_URL']))
+  config.logger = Rails.logger
+
+  # config options false, true. (defaults to false)
+  # true and debug can give helpful and interesting code usage information
+  # and is safe to use if one is investigating issues in production, but it will slightly
+  # hit perf.
+  config.verbose = false
+
+  # default false. button at the top of the web interface which clears all data
+  config.web_enable_clear = true
+
+  # default false. Experimental support for tracking view layer tracking.
+  # Does not track line-level usage, only indicates if an entire file
+  # is used or not.
+  config.track_views = true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,13 @@ Tasklets::Application.routes.draw do
     end
   end
 
+  # Devise authentication. This is a super kludge.
+  # https://github.com/danmayer/coverband#mounting-as-a-rack-app
+  # TODO: https://doolin.atlassian.net/browse/TASKLETS-114
+  authenticate :user, ->(u) { u.id == 1 } do
+    mount Coverband::Reporters::Web.new, at: '/coverage'
+  end
+
   authenticated do
     root to: "secret#index", as: :authenticated_root
   end


### PR DESCRIPTION
This commit is a bit of a kludge as it's going to
authenticate against first user rather than a proper
admin user. With redis operating, this runs in localhost.
This change should see it operating in heroku.

Follow up for proper admin user in
https://doolin.atlassian.net/browse/TASKLETS-114