### PR TITLE
TASKLETS-99 update rubocop-ast to 0.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
       rubocop-ast (>= 0.5.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.6.0)
+    rubocop-ast (0.7.1)
       parser (>= 2.7.1.5)
     rubocop-performance (1.8.1)
       rubocop (>= 0.87.0)


### PR DESCRIPTION
Minor bugfix for jruby:
https://github.com/rubocop-hq/rubocop-ast/blob/master/CHANGELOG.md#071-2020-09-28

Removes dependency on strscn.