### PR TITLE
TASKLETS-110 update jasmine-core gem to 3.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    jasmine-core (3.5.0)
+    jasmine-core (3.6.0)
     jasmine-rails (0.15.0)
       jasmine-core (>= 1.3, < 4.0)
       phantomjs (>= 1.9)


### PR DESCRIPTION
From the release notes: https://github.com/jasmine/jasmine/blob/main/release_notes/3.6.0.md

This is a pretty big release with a lot of small feature
updates and bug fixes. It doesn't appear there should be
any breaking changes.