### PR TITLE
TASKLETS-109 Update jquery-rails gem to 4.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       railties (>= 3.2.0)
       sprockets-rails
     jmespath (1.4.0)
-    jquery-rails (4.3.5)
+    jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)


### PR DESCRIPTION
From the Changelog: https://github.com/rails/jquery-rails/blob/master/CHANGELOG.md#440

* update jquery to 3.5.1 (note: 3.5.0 contains important security updates)
* unescape dollar signs and backticks in assert_select_jquery to match Rails updated behavior.