### PR TITLE
TASKLETS-107 update coverband gem to 5.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
-    coverband (5.0.1)
+    coverband (5.0.2)
       redis
     crass (1.0.6)
     cucumber (3.1.2)


### PR DESCRIPTION
From the release log: https://github.com/danmayer/coverband/releases/tag/v5.0.2

* change default port of local server
* update on readme about issue with scout app, thanks @mrbongiolo
* fix on configuration page not loading when redis can't load