### PR TITLE
TASKLETS-120 update aws-partitions gem to 1.380.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     ast (2.4.1)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.378.0)
+    aws-partitions (1.380.0)
     aws-sdk-core (3.108.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
From the changelog:
https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-partitions/CHANGELOG.md#13800-2020-10-02

Updated the partitions source data the determines the AWS service regions and endpoints.

---

I believe the gem work with the following:
https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/Partitions.html

"A Partition is a group of AWS Region and Service objects. You can use a
partition to determine what services are available in a region, or what
regions a service is available in."