### PR TITLE
TASKLETS-121 update aws-sdk-code gem to 3.109.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
     aws-partitions (1.380.0)
-    aws-sdk-core (3.108.0)
+    aws-sdk-core (3.109.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)


### PR DESCRIPTION
From the changelog:
https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/CHANGELOG.md#31090-2020-09-30

Feature - Add Seahorse::Util.host_label? to check strings for valid RFC-3986 host labels.
Feature - Add Aws::ARN#to_h