### PR TITLE
TASKLETS-123

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,7 +403,7 @@ GEM
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)


### PR DESCRIPTION
From the release log:
https://github.com/rails/sprockets-rails/releases/tag/v3.2.2

* Fix extending ActionView::Base instances with Sprockets::Rails::Helper on Rails 6.1
* Fix deprecation warning on Ruby 2.7 [#454]
* action_view/base is no longer required when rake tasks are loaded [#455]
* Asset not precompiled error exception renamed to AssetNotPrecompiledError [#414]