### PR TITLE
TASKLETS-126 update  rspec-core gem to version 3.9.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
       activemodel (>= 3.0)
       activesupport (>= 3.0)
       rspec-mocks (>= 2.99, < 4.0)
-    rspec-core (3.9.2)
+    rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)


### PR DESCRIPTION
From the changelog:
https://github.com/rspec/rspec-core/blob/v3.9.3/Changelog.md#393--2020-09-30

Bug Fixes:

    Declare ruby2_keywords on method_missing for other gems. (Jon Rowe, #2731)
    Ensure custom error codes are returned from bisect runs. (Jon Rowe, #2732)
    Ensure RSpec::Core::Configuration predicate config methods return booleans. (Marc-André Lafortune, #2736)
    Prevent rspec --bisect from generating zombie processes while executing bisect runs. (Benoit Tigeot, Jon Rowe, #2739)
    Predicates for pending examples, (in RSpec::Core::Example, #pending?, #skipped? and #pending_fixed?) now return boolean values rather than truthy values. (Marc-André Lafortune, #2756, #2758)
    Exceptions which have a message which cannot be cast to a string will no longer cause a crash. (Jon Rowe, #2761)