### PR TITLE
TASKLETS-131 update  coverband gem to version 5.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
-    coverband (5.0.2)
+    coverband (5.0.3)
       redis
     crass (1.0.6)
     cucumber (3.1.2)


### PR DESCRIPTION
https://doolin.atlassian.net/browse/TASKLETS-131

From the release pgae:
https://github.com/danmayer/coverband/releases/tag/v5.0.3

* fix for non standard root paths for view_tracker thx @markshawtoronto
* support basic auth for Rack prior to 2.0 thx @kadru