### PR TITLE
TASKLETS-124 update  aws-partitions gem to version 1.381.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     ast (2.4.1)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.380.0)
+    aws-partitions (1.381.0)
     aws-sdk-core (3.109.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
From the changelog:
https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-partitions/CHANGELOG.md#13810-2020-10-09

Partition source data updated.