### PR TITLE
TASKLETS-138 update aws-partitions partitione gem to 1.382.0

### DIFF
--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -2,7 +2,7 @@ name: PR lint
 
 on:
   pull_request:
-    types: [opened', 'edited', 'reopened', 'synchronize']
+    types: ['opened', 'edited', 'reopened', 'synchronize']
 
 jobs:
   pr-lint:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     ast (2.4.1)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.381.0)
+    aws-partitions (1.382.0)
     aws-sdk-core (3.109.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
From the Changelog:
https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-partitions/CHANGELOG.md#13820-2020-10-15

Updated the partitions source data the determines the AWS service
regions and endpoints.