### PR TITLE
TASKLETS-159 swap children between two tasks

### DIFF
--- a/doc/images/swap_children.drawio.svg
+++ b/doc/images/swap_children.drawio.svg
@@ -1,0 +1,144 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="561px" height="321px" viewBox="-0.5 -0.5 561 321" content="&lt;mxfile&gt;&lt;diagram id=&quot;unnUHGNt_Q6_YqUf8NdF&quot; name=&quot;Page-1&quot;&gt;5VlBb5swFP41XCewgaTHNe22wypNy2Hr0QM3WIIYGaeB/foZ2QZsB9qlUUGplIPfx/Pz8+dPfi/gwU1Rf2WozB5oinMP+GntwTsPgBsAvPbnp40E4lUsgR0jqYSCHtiSv1iBvkIPJMWV4cgpzTkpTTCh+z1OuIEhxujRdHuiublqiXbYAbYJyl30F0l5JtF15Pf4N0x2mV458NWTAmlnBVQZSulxAMF7D24YpVyOinqD85Y7zYuc92XkaZcYw3v+mgnqIJ5RflB7+9muLXPjjd7wMSMcb0uUtPZRnKkHbzNe5MIKxBBVpaT5idRYRL5VUTHjuB7NLOj2K3SCaYE5a4SLmgDWiiKlEW0eB4QrKBtwrTGkjnjXBe5ZEANFxGlSoEPKd4xSgQRLICYAJjHAfz9mwjFmwBKYCcP5mIkcZh5w8QezpagGxiY3ELwfN/E4N4vQTQTm42a1cN2E81GzXrhsuutlBm5uHG4cRvA+/dz2OsJKclRVJDEpEbtkzW9h+J8ibT62pjbuasNqtFUTPpgmrEcdUYz7Sa2h58jkcOq0VRbXYgP0wBJsNCccsR3mgwLknsiA8egE4xpjOEecPJtJnDoGtcIPSkR6o3doV4l1CJm8mjXsuqxAYWAGWllx5I6dOOI4UTNwK1uHaiJf614L1v50WutJfzGQGfQK7Y7gVaLVu75u1YauauM5VWtXt+5K/1/VxmO14MKytWUI/WnZRnZr419YtsFHkC2cU6N2KT1bo6P9yoU1Gkxr7uW8Lq1R8BE0eqIhmFe2dsE8uyGw9e8voyOwZX7xjsB91XKFsp1Vo87ronOvVrsqL+RmnW4W3q5Q95XXFSp01r9Vzmu7cxVq36JLaVCdvN6mUWH2Hwike/+VBd7/Aw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="240" y="0" width="80" height="80" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 40px; margin-left: 241px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Root
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="280" y="44" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Root
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="120" width="80" height="80" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 160px; margin-left: 81px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Lead 1
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="120" y="164" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Lead 1
+                </text>
+            </switch>
+        </g>
+        <rect x="400" y="120" width="80" height="80" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 160px; margin-left: 401px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Lead 2
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="440" y="164" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Lead 2
+                </text>
+            </switch>
+        </g>
+        <rect x="320" y="240" width="80" height="80" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 280px; margin-left: 321px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Member 1
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="360" y="284" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Member 1
+                </text>
+            </switch>
+        </g>
+        <rect x="480" y="240" width="80" height="80" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 280px; margin-left: 481px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Member 2
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="520" y="284" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Member 2
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="240" width="80" height="80" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 280px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Member 1
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="40" y="284" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Member 1
+                </text>
+            </switch>
+        </g>
+        <rect x="160" y="240" width="80" height="80" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 280px; margin-left: 161px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Member 2
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="200" y="284" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Member 2
+                </text>
+            </switch>
+        </g>
+        <path d="M 280 80 L 280 90 Q 280 100 290 100 L 430 100 Q 440 100 440 106.82 L 440 113.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 440 118.88 L 436.5 111.88 L 440 113.63 L 443.5 111.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 440 200 L 440 210 Q 440 220 450 220 L 510 220 Q 520 220 520 226.82 L 520 233.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 520 238.88 L 516.5 231.88 L 520 233.63 L 523.5 231.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 120 200 L 120 210 Q 120 220 130 220 L 190 220 Q 200 220 200 226.82 L 200 233.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 200 238.88 L 196.5 231.88 L 200 233.63 L 203.5 231.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 280 80 L 280 90 Q 280 100 270 100 L 130 100 Q 120 100 120 106.82 L 120 113.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 120 118.88 L 116.5 111.88 L 120 113.63 L 123.5 111.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 120 200 L 120 210 Q 120 220 110 220 L 50 220 Q 40 220 40 226.82 L 40 233.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 40 238.88 L 36.5 231.88 L 40 233.63 L 43.5 231.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 440 200 L 440 210 Q 440 220 430 220 L 370 220 Q 360 220 360 226.82 L 360 233.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 360 238.88 L 356.5 231.88 L 360 233.63 L 363.5 231.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/doc/task-model.md
+++ b/doc/task-model.md
@@ -1,0 +1,7 @@
+# Task model
+
+Operating on and persisting a tree structure
+
+## Updating the structure
+
+![Swapping children](images/swap_children.drawio.svg)


### PR DESCRIPTION
Implementing `update` depends on what, exactly is
being updated. Updating the structure of the tree
is distinctly different than updating a record in
the database.

`swap_children` does what it says: takes two nodes
and swaps the children from one to another.

The Rails implementation is interesting as the
local state in the application serves as the `temp`
variable in a swapping routine. Updating a Rails
collection proxy won't work, one task ends up with
all the children.